### PR TITLE
Content chains hooks

### DIFF
--- a/apps/lilium/less/contentchains.less
+++ b/apps/lilium/less/contentchains.less
@@ -10,17 +10,20 @@
         padding: 25px;
     }
 
-    .content-chain-no-image {
+    .chain-title {
+        margin: 6px;
+    }
+}
+
+.content-chain-list-item {
+    .no-image {
         width: 320px;
         height: 320px;
         background-color: @lesswhiteish;
+        color: #333;
         display: flex;
         align-items: center;
         justify-content: center;
-    }
-
-    .chain-title {
-        margin: 6px;
     }
 }
 

--- a/apps/lilium/pages/contentchains/list.js
+++ b/apps/lilium/pages/contentchains/list.js
@@ -3,6 +3,7 @@ import { BigList } from '../../widgets/biglist';
 import dateformat from 'dateformat';
 import { Link } from '../../routing/link';
 import { castOverlay } from '../../overlay/overlaywrap';
+import { ButtonWorker } from '../../widgets/form';
 
 class ContentChainListItem extends Component {
     constructor(props) {
@@ -12,15 +13,15 @@ class ContentChainListItem extends Component {
     
     render() {
         return (
-            <div class="card flex">
+            <div class="card flex content-chain-list-item">
                 <div class="image-wrapper">
-                    <Link href={`/chains/edit/${this.props.item._id}`}>
+                    <Link display="block" href={`/chains/edit/${this.props.item._id}`}>
                     {
                         (this.props.item.media) ? (
                             <img src={this.props.item.media.sizes.square.url} alt=""/>
-                            ) : (
-                                <div className="no-image">
-                                No Image
+                        ) : (
+                            <div className="no-image">
+                                <span>No Featured Image</span>
                             </div>
                         )
                     }
@@ -86,7 +87,8 @@ export class ListContentChains extends Component {
     render() {
         return (
             <div id="content-chains-list">
-                <BigList listitem={ContentChainListItem} addComponent={ContentChainListItemAdd} endpoint='/chains/search' toolbar={ListContentChains.TOOLBAR_CONFIG} />
+                <BigList listitem={ContentChainListItem} addComponent={ContentChainListItemAdd}
+                        endpoint='/chains/search' toolbar={ListContentChains.TOOLBAR_CONFIG} />
             </div>
         );
     }

--- a/apps/lilium/widgets/biglist.js
+++ b/apps/lilium/widgets/biglist.js
@@ -45,7 +45,7 @@ export class BigList extends Component {
             component : props.listitem,
             addComponent : props.addComponent || BigListNullComponent,
             topElement : props.topElement,
-            emptyComponent : props.emptyComponent || BigListEmptyTemplate,
+            emptyComponent : props.emptyComponent || props.addComponent || BigListEmptyTemplate,
             index : 0,
             batchsize : props.batchsize || 30,
             livevarkey : typeof props.livevarkey == "undefined" ? "items" : props.livevarkey,
@@ -147,7 +147,11 @@ export class BigList extends Component {
 
                         {
                             this.state.items.length == 0 ? (
-                                <this.coldState.emptyComponent />
+                                this.coldState.emptyComponent ? (
+                                    <this.coldState.emptyComponent />
+                                ) : (
+                                    (<this.coldState.addComponent />)
+                                )
                             ) : [(<this.coldState.addComponent />), ...this.state.items.map(x => (
                                 <this.coldState.component action={this.props.action} item={x} key={x[this.props.keyid || "_id"]} />
                             ))]

--- a/controllers/contentchains.js
+++ b/controllers/contentchains.js
@@ -28,7 +28,19 @@ class ContentChains {
         }
 
         if (levels[0] == "bunch") {
-            cclib.getChains(cli, params, sendback);
+            cclib.getChains(cli, params, data => {
+                data.chains.forEach(item => {
+                    let img = item.media.pop();
+                    if (img) {
+                        item.featuredimageurl = img.sizes.square.url;
+                    }
+    
+                    item.featuredimage = undefined;
+                    item.featuredMedia = undefined;
+                });
+
+                sendback && sendback(data);
+            });
         } else if (levels[0] == "deep") {
             cclib.deepFetch(cli._c, { _id : db.mongoID(levels[1]) }, (item) => {
                 sendback(item);

--- a/controllers/contentchains.js
+++ b/controllers/contentchains.js
@@ -115,7 +115,8 @@ class ContentChains {
         if (path == "new") {
             cclib.insertNewChain(cli._c, {
                 title : cli.postdata.data.title,
-                subtitle : cli.postdata.data.subtitle,                
+                subtitle : cli.postdata.data.subtitle,
+                slug: require('slugify')(cli.postdata.data.title).toLowerCase(),
                 createdBy : db.mongoID(cli.userinfo.userid)
             }, (err, r) => {
                 cli.sendJSON({

--- a/controllers/contentchains.js
+++ b/controllers/contentchains.js
@@ -28,7 +28,7 @@ class ContentChains {
         }
 
         if (levels[0] == "bunch") {
-            cclib.bunchLivevar(...arguments);
+            cclib.getChains(cli, params, sendback);
         } else if (levels[0] == "deep") {
             cclib.deepFetch(cli._c, { _id : db.mongoID(levels[1]) }, (item) => {
                 sendback(item);

--- a/lib/contentchains.js
+++ b/lib/contentchains.js
@@ -3,22 +3,28 @@ const hooks = require('./hooks');
 const filelogic = require('../pipeline/filelogic');
 const articleLib = require('./content.js');
 
-const CONTENTCHAIN_LIVEVAR_PROJECTION = {
+const CHAIN_DEEP_PROJECTION = {
     title : 1,
     subtitle : 1,
     slug : 1,
     presentation : 1,
     status : 1,
-    createdBy : 1,
-    createdOn : 1,
-    lastModified : 1,
     language : 1,
-    edition : 1,
-    media: 1,
-    
+    lastModified : 1,
+
+    'featuredimage' : '$media.sizes.facebook.url',
+    'thumbnail' : '$media.sizes.thumbnaillarge.url',
+    'square' : '$media.sizes.thumbnail.url',
+
     'articles._id': 1,
     'articles.title': 1,
-    'articles.date': 1
+    'articles.subtitle': 1,
+    'articles.facebookmedia' : 1,
+    'articles.date': 1,
+
+    'alleditions._id' : 1,
+    'alleditions.displayname' : 1,
+    'alleditions.slug' : 1
 };
 
 class ContentChainsLib {
@@ -122,7 +128,7 @@ class ContentChainsLib {
                 }
             }, 
             { $unwind : "$media" },
-            { $project : projection || CONTENTCHAIN_LIVEVAR_PROJECTION }
+            { $project : projection || CHAIN_DEEP_PROJECTION }
         ], items => {
             send(items[0]);
         });

--- a/lib/contentchains.js
+++ b/lib/contentchains.js
@@ -41,7 +41,6 @@ class ContentChainsLib {
             lastModified : new Date(),
             media: undefined,
             edition : [],
-            serie : []
         }, data);
     }
 
@@ -135,11 +134,10 @@ class ContentChainsLib {
         });
     }
 
-    bunchLivevar(cli, levels, params, send) {
+    getChains(cli, params, cb) {
         let filters = params.filters || {};
         let page = (params.page || 1) - 1;
         let max = params.max || 25;
-
         let query = {};
 
         // Allowed filters
@@ -150,6 +148,7 @@ class ContentChainsLib {
         if (max < 1) {
             max = 25;
         }
+
 
         db.join(cli._c, 'contentchains', [{
             $match : query
@@ -166,22 +165,74 @@ class ContentChainsLib {
                 foreignField : "_id",
                 as : "media"
             }
-        }], (items) => {
-            items.forEach(item => {
-                let img = item.featuredimage.pop();
-                if (img) {
-                    item.featuredimageurl = img.sizes.square.url;
-                }
-
-                item.featuredimage = undefined;
-                item.featuredMedia = undefined;
-            });
-
-            db.count(cli._c, 'contentchains', query, (err, total) => {
-                send({ items, total });
-            });
+        }], items => {
+            if (items && items.length) {
+                items.forEach(item => {
+                    let img = item.media.pop();
+                    if (img) {
+                        item.featuredimageurl = img.sizes.square.url;
+                    }
+    
+                    item.featuredimage = undefined;
+                    item.featuredMedia = undefined;
+                });
+    
+                db.count(cli._c, 'contentchains', query, (err, total) => {
+                    cb({ items, total });
+                });
+            } else {
+                cli.throwHTTP(400, 'No content chain found', true);
+            }
         });
     }
+
+    // bunchLivevar(cli, levels, params, send) {
+    //     let filters = params.filters || {};
+    //     let page = (params.page || 1) - 1;
+    //     let max = params.max || 25;
+
+    //     let query = {};
+
+    //     // Allowed filters
+    //     if (filters.status) {
+    //         query.status = filters.status;
+    //     }
+
+    //     if (max < 1) {
+    //         max = 25;
+    //     }
+
+    //     db.join(cli._c, 'contentchains', [{
+    //         $match : query
+    //     }, {
+    //         $sort : {_id : -1}
+    //     }, {
+    //         $skip : ((page < 0 ? 0 : page) * max)
+    //     }, {
+    //         $limit : max
+    //     }, {
+    //         $lookup : {
+    //             from : "uploads",
+    //             localField : "media",
+    //             foreignField : "_id",
+    //             as : "media"
+    //         }
+    //     }], (items) => {
+    //         items.forEach(item => {
+    //             let img = item.featuredimage.pop();
+    //             if (img) {
+    //                 item.featuredimageurl = img.sizes.square.url;
+    //             }
+
+    //             item.featuredimage = undefined;
+    //             item.featuredMedia = undefined;
+    //         });
+
+    //         db.count(cli._c, 'contentchains', query, (err, total) => {
+    //             send({ items, total });
+    //         });
+    //     });
+    // }
 }
 
 module.exports = new ContentChainsLib();

--- a/lib/contentchains.js
+++ b/lib/contentchains.js
@@ -3,28 +3,22 @@ const hooks = require('./hooks');
 const filelogic = require('../pipeline/filelogic');
 const articleLib = require('./content.js');
 
-const CHAIN_DEEP_PROJECTION = {
+const CONTENTCHAIN_LIVEVAR_PROJECTION = {
     title : 1,
     subtitle : 1,
     slug : 1,
     presentation : 1,
     status : 1,
-    language : 1,
+    createdBy : 1,
+    createdOn : 1,
     lastModified : 1,
-
-    'featuredimage' : '$media.sizes.facebook.url',
-    'thumbnail' : '$media.sizes.thumbnaillarge.url',
-    'square' : '$media.sizes.thumbnail.url',
-
+    language : 1,
+    edition : 1,
+    media: 1,
+    
     'articles._id': 1,
     'articles.title': 1,
-    'articles.subtitle': 1,
-    'articles.facebookmedia' : 1,
-    'articles.date': 1,
-
-    'alleditions._id' : 1,
-    'alleditions.displayname' : 1,
-    'alleditions.slug' : 1
+    'articles.date': 1
 };
 
 class ContentChainsLib {
@@ -101,7 +95,7 @@ class ContentChainsLib {
         });
     }
 
-    deepFetch(_c, $match, send) {
+    deepFetch(_c, $match, send, projection) {
         db.join(_c, 'contentchains', [ 
             { $match },
             { $limit : 1 },
@@ -127,10 +121,10 @@ class ContentChainsLib {
                     localField : "articles"
                 }
             }, 
-            { $unwind : "$media" }, 
-            { $project : CHAIN_DEEP_PROJECTION }
-        ], (item) => {
-            send(item[0]);
+            { $unwind : "$media" },
+            { $project : projection || CONTENTCHAIN_LIVEVAR_PROJECTION }
+        ], items => {
+            send(items[0]);
         });
     }
 
@@ -149,7 +143,6 @@ class ContentChainsLib {
             max = 25;
         }
 
-
         db.join(cli._c, 'contentchains', [{
             $match : query
         }, {
@@ -167,16 +160,6 @@ class ContentChainsLib {
             }
         }], chains => {
             if (chains && chains.length) {
-                chains.forEach(item => {
-                    let img = item.media.pop();
-                    if (img) {
-                        item.featuredimageurl = img.sizes.square.url;
-                    }
-    
-                    item.featuredimage = undefined;
-                    item.featuredMedia = undefined;
-                });
-    
                 db.count(cli._c, 'contentchains', query, (err, total) => {
                     cb({ chains, total });
                 });

--- a/lib/contentchains.js
+++ b/lib/contentchains.js
@@ -1,4 +1,5 @@
 const db = require('./db.js');
+const hooks = require('./hooks');
 const filelogic = require('../pipeline/filelogic');
 const articleLib = require('./content.js');
 
@@ -62,7 +63,10 @@ class ContentChainsLib {
 
     insertNewChain(_c, data, callback) {
         let newChain = this.createFromObject(data);
-        db.insert(_c, 'contentchains', newChain, callback);
+        db.insert(_c, 'contentchains', newChain, (err, r) => {
+            hooks.fireSite("content_chain_created");
+            callback && callback(err, r);
+        });
     }
 
     handleStatusChange(_c, id, callback) {
@@ -90,15 +94,18 @@ class ContentChainsLib {
             data.serie = data.serie.map(x => db.mongoID(x));
         }
 
-        db.update(_c, 'contentchains', {_id : db.mongoID(id)}, data, (err) => {
-            callback && callback(err);
+        db.update(_c, 'contentchains', {_id : db.mongoID(id)}, data, (err, r) => {
+            this.deepFetch(_c, { _id : db.mongoID(id) }, chain => {
+                hooks.fireSite(_c, "content_chain_updated", chain);
+                callback && callback(err);
+            });
         });
     }
 
     deepFetch(_c, $match, send) {
         db.join(_c, 'contentchains', [ 
-            { $match }, 
-            { $limit : 1 }, 
+            { $match },
+            { $limit : 1 },
             {
                 $lookup : {
                     from : "uploads",

--- a/lib/contentchains.js
+++ b/lib/contentchains.js
@@ -165,9 +165,9 @@ class ContentChainsLib {
                 foreignField : "_id",
                 as : "media"
             }
-        }], items => {
-            if (items && items.length) {
-                items.forEach(item => {
+        }], chains => {
+            if (chains && chains.length) {
+                chains.forEach(item => {
                     let img = item.media.pop();
                     if (img) {
                         item.featuredimageurl = img.sizes.square.url;
@@ -178,61 +178,13 @@ class ContentChainsLib {
                 });
     
                 db.count(cli._c, 'contentchains', query, (err, total) => {
-                    cb({ items, total });
+                    cb({ chains, total });
                 });
             } else {
-                cli.throwHTTP(400, 'No content chain found', true);
+                cb({ chains: [], total: 0 });
             }
         });
     }
-
-    // bunchLivevar(cli, levels, params, send) {
-    //     let filters = params.filters || {};
-    //     let page = (params.page || 1) - 1;
-    //     let max = params.max || 25;
-
-    //     let query = {};
-
-    //     // Allowed filters
-    //     if (filters.status) {
-    //         query.status = filters.status;
-    //     }
-
-    //     if (max < 1) {
-    //         max = 25;
-    //     }
-
-    //     db.join(cli._c, 'contentchains', [{
-    //         $match : query
-    //     }, {
-    //         $sort : {_id : -1}
-    //     }, {
-    //         $skip : ((page < 0 ? 0 : page) * max)
-    //     }, {
-    //         $limit : max
-    //     }, {
-    //         $lookup : {
-    //             from : "uploads",
-    //             localField : "media",
-    //             foreignField : "_id",
-    //             as : "media"
-    //         }
-    //     }], (items) => {
-    //         items.forEach(item => {
-    //             let img = item.featuredimage.pop();
-    //             if (img) {
-    //                 item.featuredimageurl = img.sizes.square.url;
-    //             }
-
-    //             item.featuredimage = undefined;
-    //             item.featuredMedia = undefined;
-    //         });
-
-    //         db.count(cli._c, 'contentchains', query, (err, total) => {
-    //             send({ items, total });
-    //         });
-    //     });
-    // }
 }
 
 module.exports = new ContentChainsLib();


### PR DESCRIPTION
Separated content chains lib and controller a bit better
The content chain lib will take a projection as argument and fallback to a default one if none is provided.
To get all the data, it is possible to pass an empty object `{}` as the projection.