### PR TITLE
Two-setp 2FA

### DIFF
--- a/apps/lilium/less/publishing.less
+++ b/apps/lilium/less/publishing.less
@@ -98,6 +98,18 @@
 
         &.publishing-create-article {
             cursor: pointer;
+            .article-list-image-wrapper {
+                background: @liliumPurple;
+                background: -webkit-linear-gradient(35deg, #b48efb 0%, #f777e1 100%);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                border-radius: 6px;
+
+                & > i {
+                    color: white;
+                }
+            }
         }
 
         .article-list-image-wrapper {

--- a/apps/lilium/pages/publishing/list.js
+++ b/apps/lilium/pages/publishing/list.js
@@ -57,7 +57,7 @@ class PostListItemAdd extends Component {
     render() {
         return (
             <div onClick={this.onClick.bind(this)} class="flex-row publishing-list-item publishing-create-article">
-                <div class="flex-col article-list-image-wrapper gray-background"></div>
+                <div class="flex-col article-list-image-wrapper"><i className="fa fa-plus"></i></div>
                 <div class="flex-col article-list-title">
                     <b>Create new article</b>
                 </div>

--- a/backend/dynamic/login.lml3
+++ b/backend/dynamic/login.lml3
@@ -87,6 +87,14 @@ h1 {
     box-shadow: 0px 3px 3px rgba(0,0,0,0.5);
 }
 
+#loginformfields[data-auth-step="2fa"] input[name="username"],
+#loginformfields[data-auth-step="2fa"] input[name="password"],
+#loginformfields[data-auth-step="2fa"] button#loginbutton,
+#loginformfields[data-auth-step="credentials"] button#submit2fa,
+    #loginformfields[data-auth-step="credentials"] input[name="2fa"] {
+    display: none;
+}
+
 input {
     display: block;
     margin: 12px auto 20px;
@@ -110,7 +118,7 @@ input:focus {
     text-align: left;
 }
 
-#loginbutton {
+button {
     background: #fff;
     border: none;
     padding: 6px 11px;
@@ -135,8 +143,11 @@ input:focus {
 #loginmsg {
     display: none;
     margin-bottom: 20px;
-    color: #fd7c7c;
     font-weight: bold;
+    color: #333;
+}
+#loginmsg.error {
+    color: #fd7c7c;
 }
 
 `;
@@ -159,15 +170,16 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
                     <h1>Lilium CMS</h1>
                     <img src="/static/media/lmllogo.png" id="logo" />
                 </div>
-                <div id="loginformfields">
-                    <input type="text" placeholder="Username" id="txtusername" />
-                    <input type="password" placeholder="Password" id="txtpassword" />
-                    <input type="text" placeholder="2FA Token" id="txt2fa" />
+                <div id="loginformfields" data-auth-step='credentials'>
+                    <input type="text" name='username' placeholder="Username" id="txtusername" />
+                    <input type="password" name='password' placeholder="Password" id="txtpassword" />
+                    <input type="text" name='2fa' placeholder="2FA Token" id="txt2fa" />
 
                     <div id="loginmsg"></div>
 
                     <div id="loginwrap">
                         <button id="loginbutton">Login</button>
+                        <button id="submit2fa">Submit</button>
 
                         <a id="pwdforgot" href="/accesscheckpoint">
                             I have no idea what my password is
@@ -204,7 +216,7 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
             document.getElementById('txtusername').focus();
 
             if (document.location.hash) {
-                document.querySelector('input[name="usr"]').value = document.location.hash.toString().substring(1);
+                document.querySelector('input[name="username"]').value = document.location.hash.toString().substring(1);
                 history.pushState("", document.title, window.location.pathname + window.location.search);
             }
 
@@ -228,16 +240,30 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
                 token2fa.value = "";
 
                 document.getElementById('loginbutton').style.display = "";
-                document.getElementById('loginmsg').style.display = "block";
-                document.getElementById('loginmsg').textContent = msg || "Login failed."
+                var loginMsg = document.getElementById('loginmsg');
+                loginMsg.style.display = "block";
+                loginMsg.classList.add('error');
+                loginMsg.textContent = msg || "Login failed."
             }
 
-            var gotLoginResp = function() {
+            var challenge2fa = function(msg) {
+                var loginMsg = document.getElementById('loginmsg');
+                loginMsg.style.display = "block";
+                loginMsg.classList.remove('error');
+                loginMsg.textContent = msg || "Two factor authentication token required";
+                document.getElementById('txt2fa').focus();
+            }
+
+            var getCredentialsResp = function() {
                 if (this.status == 200) {
                     var resp = JSON.parse(this.responseText);
 
-                    if (resp.success) {
+                    if (resp.status == 'success') {
                         document.location = resp.to;
+                    } else if (resp.status == '2fachallenge') {
+                        var form = document.getElementById('loginformfields');
+                        form.dataset.authStep = '2fa';
+                        challenge2fa(resp.message);
                     } else {
                         failed(resp.message);
                     }
@@ -246,7 +272,7 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
                 }   
             }
 
-            var login = function() {
+            var submitLoginInfo = function() {
                 document.getElementById('loginbutton').style.display = "none";
                 document.getElementById('loginmsg').style.display = "";
 
@@ -258,7 +284,7 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
                     failed();
                 } else {
                     var oReq = new XMLHttpRequest();
-                    oReq.addEventListener("load", gotLoginResp);
+                    oReq.addEventListener("load", getCredentialsResp);
                     oReq.open("POST", "/login" + document.location.search);
                     oReq.setRequestHeader('Content-Type', 'application/json');
                     oReq.send(JSON.stringify({ usr : username, psw : password, token2fa : txt2fa, payloadid : "${Math.random().toString().substring(2)}" }));
@@ -267,7 +293,7 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
 
             var onkeydown = function(ev) {
                 if (ev.keyCode == 13) { 
-                    login();
+                    submitLoginInfo();
 
                     ev.preventDefault();
                     return;
@@ -279,8 +305,10 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
 
             document.getElementById('txtusername').addEventListener('keypress', onkeydown);
             document.getElementById('txtpassword').addEventListener('keypress', onkeydown);
+            document.getElementById('txt2fa').addEventListener('keypress', onkeydown);
 
-            document.getElementById('loginbutton').addEventListener('click', login);
+            document.getElementById('loginbutton').addEventListener('click', submitLoginInfo);
+            document.getElementById('submit2fa').addEventListener('click', submitLoginInfo);
         </script>
 	</body>
 </html>

--- a/backend/dynamic/login.lml3
+++ b/backend/dynamic/login.lml3
@@ -85,6 +85,7 @@ h1 {
     padding-top: 15px;
     padding-bottom: 15px;
     box-shadow: 0px 3px 3px rgba(0,0,0,0.5);
+    animation: height 0.5s
 }
 
 #loginformfields[data-auth-step="2fa"] input[name="username"],
@@ -125,6 +126,13 @@ button {
     font-size: 14px;
     width: 100px;
     box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.2);
+    display: block;
+    margin: 0 auto;
+    background: #af57e4;
+    color: white;
+    cursor: pointer;
+    border-radius: 4px;
+    border: 1px solid #8d21cd;
 }
 
 #pwdforgot {
@@ -217,6 +225,7 @@ const compile = (o, context) => { o(`<!DOCTYPE html>
 
             if (document.location.hash) {
                 document.querySelector('input[name="username"]').value = document.location.hash.toString().substring(1);
+                document.querySelector('input[name="password"').focus();
                 history.pushState("", document.title, window.location.pathname + window.location.search);
             }
 


### PR DESCRIPTION
The back end login logic was modified to send a response with a status of `challenge2fa` to the user when credentials are valid but 2 factor authentication is enabled. The client can then recontact the same endpoint while including both the standard credentials and the 2fa token.

Note that a potential attacker has to first know the credentials of an account in order to know whether 2FA is enabled for it because if wrong credentials are sent, the API just responds with a 'wrong credentials' status