### PR TITLE
Synthetic events

### DIFF
--- a/apps/lilium/layout/embedpicker.js
+++ b/apps/lilium/layout/embedpicker.js
@@ -246,14 +246,14 @@ export class EmbedPicker extends Component {
     render() {
         if (this.state.loading) {
             return (
-                <div onKeyDown={this.props.onKeyDown.bind(this)}>
+                <div>
                     <Spinner centered />
                 </div>
             );
         }
 
         return (
-            <div id="embed-picker" onKeyDown={this.props.onKeyDown.bind(this)}>
+            <div id="embed-picker">
                 <div class="embed-picker-list">
                     <div class="embed-add embed-single card flex" onClick={() => this.setState({ newModalOpen : true })}>
                         <i class="fal fa-plus"></i>

--- a/apps/lilium/layout/embedpicker.js
+++ b/apps/lilium/layout/embedpicker.js
@@ -282,7 +282,8 @@ export class EmbedPicker extends Component {
                             onChange={this.newEmbedFieldChanged.bind(this)} />
                     </div>
                     <div style={{ textAlign : 'right' }}>
-                        <ButtonWorker text="Generate embed" type="outline" theme="white" work={this.fetchEmbed.bind(this)} />
+                        <ButtonWorker text="Cancel" type="outline" theme="red" sync={true} work={() => { this.setState({ newModalOpen: false }); }} />
+                        <ButtonWorker text="Generate embed" type="fill" theme="purple" work={this.fetchEmbed.bind(this)} />
                     </div>
                 </Modal>
             </div>

--- a/apps/lilium/layout/imagepicker.js
+++ b/apps/lilium/layout/imagepicker.js
@@ -263,7 +263,7 @@ export class ImagePicker extends Component {
 
     render() {
         return (
-            <div id="image-picker" onKeyDown={this.props.onKeyDown.bind(this)}>
+            <div id="image-picker">
                 <div id="image-picker-flex-wrapper">
                     <div id="image-gallery">
                         <div className="image-picker-button" onClick={this.castUpload.bind(this)}>

--- a/apps/lilium/layout/picker.js
+++ b/apps/lilium/layout/picker.js
@@ -83,7 +83,7 @@ export class Picker extends Component {
             const tabs = session.accept.map(x => PickerMap[x]);
             if (!session.options) session.options = {};
             _singleton.changeState({ session: session, visible: true, tabs, callback: done });
-            document.addEventListener('keydown', _singleton.keydown_bound);
+            window.liliumcms.bindFirst('keydown', _singleton.keydown_bound);
         } else {
             log('Picker', 'Cannot cast Picker without a Session object', 'error');
         }
@@ -106,7 +106,7 @@ export class Picker extends Component {
     static dismiss() {
         log('Picker', 'Dismissing picker singleton', 'detail');
         _singleton.setState({ visible : false });
-        document.removeEventListener('keydown', _singleton.keydown_bound);
+        window.liliumcms.unbind('keydown', _singleton.keydown_bound);
 
         // _singleton.state.callback && _singleton.state.callback(_singleton.state.selectedElement);
     }
@@ -205,7 +205,7 @@ export class Picker extends Component {
                                 {
                                     state.tabs.map((SubPicker) => (
                                         <Tab title={SubPicker.tabTitle}>
-                                            <SubPicker onKeyDown={this.keydown.bind(this)} isCarousel={state.session.type == 'carousel'} options={state.session.options[SubPicker.slug]}
+                                            <SubPicker isCarousel={state.session.type == 'carousel'} options={state.session.options[SubPicker.slug]}
                                                         selected={state.session.options[SubPicker.slug].selected} />
                                         </Tab>
                                     ))

--- a/apps/lilium/layout/placepicker.js
+++ b/apps/lilium/layout/placepicker.js
@@ -92,7 +92,7 @@ export class PlacePicker extends Component {
 
     render() {
         return (
-            <div id="place-picker" onKeyDown={this.props.onKeyDown.bind(this)}>
+            <div id="place-picker">
                 <div id="place-picker-search-pane">
                     <h1 className="title">Pick a place</h1>
                     <div id="search-content-wrapper" className='scroll-x'>

--- a/apps/lilium/main.js
+++ b/apps/lilium/main.js
@@ -89,6 +89,7 @@ import { NotificationWrapper, castNotification } from 'layout/notifications';
 import { fireEvent } from 'interactive/events';
 import { setLanguage } from 'data/vocab';
 import { CakepopWrapper } from 'layout/cakepopsmanager';
+import { bind, bindFirst, unbind } from './syntheticEvents';
 
 import API from 'data/api';
 
@@ -99,6 +100,12 @@ liliumcms.connected = true;
 
 // Create `log` function
 makeGlobalLogger();
+
+// Make synthetic events library global in window.liliumcms
+log('Lilium', "Making synthetic events library global in window.liliumcms", 'lilium');
+window.liliumcms.bind = bind;
+window.liliumcms.bindFirst = bindFirst;
+window.liliumcms.unbind = unbind;
 
 // If in dev mode, initialize dev functions
 if (liliumcms.env == "dev") {

--- a/apps/lilium/syntheticEvents.js
+++ b/apps/lilium/syntheticEvents.js
@@ -1,0 +1,64 @@
+/**
+ * This file adds globally available functions to the window.liliumcms object.
+ * Those functions can be used to bind on synthetic event to override the default browser behavior
+ */
+
+ /**
+  * Object keyed by event name to associate a single callback to a native event
+  */
+const nativeEventsMap = {};
+
+/**
+ * An object keyed by synthetic event name that holds an array of callbacks to execute
+ */
+const syntheticEventsMap = {};
+
+const bindNativeEvent = eventName => {
+    if (!Object.keys(nativeEventsMap).includes(eventName)) {
+        nativeEventsMap[eventName] = handleNativeEvent;
+        document.addEventListener(eventName, handleNativeEvent);
+    }
+
+    console.log('Native events', nativeEventsMap);
+};
+
+/**
+ * Handles the event for ALL types of native events and executes the callbacks that are subscribed
+ * to the corresponding synthetic event
+ * @param {object} e Event object
+ */
+const handleNativeEvent = e => {
+    if (syntheticEventsMap[e.type] && syntheticEventsMap[e.type].length) {
+        for (let i = 0; i < syntheticEventsMap[e.type].length; i++) {
+            const cb = syntheticEventsMap[e.type][i];
+            const rvalue = cb(e);
+            if (rvalue === false) {
+                break;
+            }
+        }
+    }
+};
+
+export const bindFirst = (eventName, handler) => {
+    if (!syntheticEventsMap[eventName]) syntheticEventsMap[eventName] = [];
+    
+    syntheticEventsMap[eventName].unshift(handler);
+    bindNativeEvent(eventName);
+};
+
+export const bind = (eventName, handler) => {
+    if (!syntheticEventsMap[eventName]) syntheticEventsMap[eventName] = [];
+    
+    syntheticEventsMap[eventName].push(handler);
+    bindNativeEvent(eventName);
+};
+
+export const unbind = (eventName, handler) => {
+    if (syntheticEventsMap[eventName]) {
+        const i = syntheticEventsMap[eventName].findIndex(h => h == handler);        
+        if (i >= 0) {
+            syntheticEventsMap[eventName].splice(i, 1);
+        }
+    }
+}
+

--- a/apps/lilium/syntheticEvents.js
+++ b/apps/lilium/syntheticEvents.js
@@ -18,8 +18,6 @@ const bindNativeEvent = eventName => {
         nativeEventsMap[eventName] = handleNativeEvent;
         document.addEventListener(eventName, handleNativeEvent);
     }
-
-    console.log('Native events', nativeEventsMap);
 };
 
 /**

--- a/apps/lilium/widgets/modal.js
+++ b/apps/lilium/widgets/modal.js
@@ -4,24 +4,32 @@ export default class Modal extends Component {
     constructor(props) {
         super(props);
         this.state = { visible: false };
+        this.bodyEl;
+        this.backgroundEl;
+        this.handleKeyDownBound = this.handleKeyDown.bind(this);
     }
 
     componentDidMount() {
-        this.props.visible && this.show();
+        if (this.props.visible) {
+            this.show();
+        }
     }
-
+    
     fireClose() {
         this.props.onClose && this.props.onClose();
     }
-
+    
     close() {
+        window.liliumcms.unbind('keydown', this.handleKeyDownBound);
         this.bodyEl && this.bodyEl.classList.remove("shown");
         setTimeout(() => this.setState({ visible: false }), 200);
     }
-
+    
     show() {
         this.setState({ visible: true }, () => {
+            window.liliumcms.bindFirst('keydown', this.handleKeyDownBound);
             this.bodyEl && setTimeout(() => this.bodyEl && this.bodyEl.classList.add("shown"), 200);
+            this.bodyEl.focus();
         });
     }
 
@@ -33,8 +41,15 @@ export default class Modal extends Component {
         }
     }
     
-    handleKeyUp(ev) {
+    handleKeyDown(ev) {
         if (ev.which == 27 || ev.keyCode == 27) {
+            this.props.onClose ? this.props.onClose() : this.close();
+            return false;
+        }
+    }
+
+    handleOutsideClick(e) {
+        if (e.target == this.backgroundEl) {
             this.props.onClose ? this.props.onClose() : this.close();
         }
     }
@@ -44,8 +59,9 @@ export default class Modal extends Component {
             return null;
         } else {
             return (
-                <div className="modal-bg" onKeyUp={this.handleKeyUp.bind(this)}>
-                    <div className="modal-body" ref={x => (this.bodyEl = x)}>
+                <div className="modal-bg" onClick={this.handleOutsideClick.bind(this)} ref={e => { this.backgroundEl = e }}>
+                    {/* Tabindex of -1 to allow for programmatic focus the element */}
+                    <div tabindex='-1' className="modal-body" ref={x => (this.bodyEl = x)}>
                         <div className="modal-header">
                             <h3 className="modal-title">{this.props.title}</h3>
                             { this.props.onClose ? (


### PR DESCRIPTION
# New Synthetic events library
Introduced a synthetic events library, see `<liliumroot>/apps/lilium/syntheticEvents.js`.
The library's functions are imported by the main application file and exposed to the global scope in `window.liliumcms`.

The library exposes these functions:
 - `bind()`: Adds an event listener for the specified event type.
 -  `bindFirst()`: Adds an event handler for the specified event type but adds it before all the currently present events so it is executed first when the event is fired
 - `unbind()`: Removes a given event handler for the specified event type

An event handler may explicitly `return false;` to cancel event propagation

The library works by registering **at most** one event handler on the `document`, regardless of how many synthetic event handlers are added. The event handler that is added as a native event handler is an internal function that, when fired, executes the synthetic event handlers.

# Fixed modals / media picker 'Escape' handling
Because of the synthetic event library, it is now possible to have multiple overlays (be it a modal, a media picker or a cakepop) and pressing escape will only close one of them, provided that the event handlers of said overlays explicitly `return false;`.