### PR TITLE
Payments

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -789,7 +789,7 @@ class ContentLib {
                     if (!err) {
                         if (author.roles.includes('contractor')) {
                             updated.paymentstatus = 'pending';
-                            updated.worth = calculateArticleWorth(post);
+                            updated.worth = this.calculateArticleWorth(post);
                         }
 
                         db.update(_c, 'content', { _id : post._id }, updated, err => {

--- a/lib/content.js
+++ b/lib/content.js
@@ -762,6 +762,13 @@ class ContentLib {
         });
     }
 
+    calculateArticleWorth(post) {
+        if (post.isSponsored) return 100;
+        else if (post.wordcount >= 1500)  return 100;
+        else if (post.wordcount >= 500) return 35;
+        else return 25;
+    }
+
     publish(_c, _id, caller, sendback) {
         this.validate(_c, _id, caller, (err, post) => {
             if (err) {
@@ -778,41 +785,60 @@ class ContentLib {
                     url : "/" + post.alleditions.map(x => x.lang[post.language || "en"].slug).join('/') + "/" + post.name
                 };
 
-                db.update(_c, 'content', { _id : post._id }, updated, () => {
-                    db.remove(_c, 'autosave', { contentid : post._id }, () => {
-                        this.pushHistoryEntryFromDiff(_c, post._id, caller, diff({}, { status : "published" }), 'published', historyentry => {
-                            this.updateActionStats(_c, post, score => {
-                                hooks.fireSite(_c, 'article_published_from_draft', { article : post, score, _c });
-                                hooks.fireSite(_c, 'article_updated', { article : post, _c });
-                                hooks.fire('article_published', {
-                                    article: post, _c
-                                });
+                db.findUnique(config.default(), 'entities', { _id: db.mongoID(post.author) }, (err, author) => {
+                    if (!err) {
+                        if (author.roles.includes('contractor')) {
+                            updated.paymentstatus = 'pending';
+                            updated.worth = calculateArticleWorth(post);
+                        }
 
-                                this.generate(_c, post, () => {
-                                    sendback({ historyentry, newstate : post });
+                        db.update(_c, 'content', { _id : post._id }, updated, err => {
+                            if (!err) {
+                                db.remove(_c, 'autosave', { contentid : post._id }, () => {
+                                    this.pushHistoryEntryFromDiff(_c, post._id, caller, diff({}, { status : "published" }), 'published', historyentry => {
+                                        this.updateActionStats(_c, post, score => {
+                                            hooks.fireSite(_c, 'article_published_from_draft', { article : post, score, _c });
+                                            hooks.fireSite(_c, 'article_updated', { article : post, _c });
+                                            hooks.fire('article_published', {
+                                                article: post, _c
+                                            });
 
-                                    notifications.emitToWebsite(_c.id, {
-                                        articleid : post._id,
-                                        at : Date.now(),
-                                        by : caller
-                                    }, "articlePublished");
+                                            this.generate(_c, post, () => {
+                                                sendback({ historyentry, newstate : post });
 
-                                    if (caller.toString() != (post.author && post.author.toString())) {
-                                        notifications.notifyUser(post.author, _c.id, {
-                                            title: "Article published",
-                                            msg: post.title + ' was published on the website.',
-                                            type: 'success'
+                                                notifications.emitToWebsite(_c.id, {
+                                                    articleid : post._id,
+                                                    at : Date.now(),
+                                                    by : caller
+                                                }, "articlePublished");
+
+                                                if (caller.toString() != (post.author && post.author.toString())) {
+                                                    notifications.notifyUser(post.author, _c.id, {
+                                                        title: "Article published",
+                                                        msg: post.title + ' was published on the website.',
+                                                        type: 'success'
+                                                    });
+                                                }
+                                            }, 'all');
                                         });
-                                    }
-                                }, 'all');
-                            });
+                                    });
+                                });
+                            } else {
+                                log('Publishing', 'Error content on article publish', 'err');
+                                console.log(err);
+                                sendback({ error: err.toString(), code: 500, stack: config.default().env == 'dev' ? err : undefined });
+                            }
                         });
-                    });
+                    } else {
+                        log('Publishing', 'Error fetching author on article publish', 'err');
+                        console.log(err);
+                        sendback({ error: err.toString(), code: 500, stack: config.default().env == 'dev' ? err : undefined });
+                    }
                 });
             } catch (err) {
                 log('Publishing', 'Error validating post', 'err');
                 console.log(err);
-                sendback({ error : err.toString(), code : 500, stack : err });
+                sendback({ error : err.toString(), code : 500, stack : config.default().env == 'dev' ? err : undefined });
             }
         });
     }


### PR DESCRIPTION
# Fixes
For V4, we migrated the contractors plugin to a core feature of Lilium, since then, articles wouldn't have a worth and payment status attributed to them on publish, this is fixed by this PR.

# Important
It's worth noting that all the article that were written between the launch of v4 and the merge of this PR will need to be manually attributed a worth and a payment status in the database **before the next payout**.